### PR TITLE
Fix the NTP CFG typedef

### DIFF
--- a/lwesp/src/include/lwesp/lwesp_typedefs.h
+++ b/lwesp/src/include/lwesp/lwesp_typedefs.h
@@ -564,7 +564,7 @@ typedef struct lwesp_evt {
             uint32_t time;                      /*!< Time required for ping. Valid only if operation succedded */
         } ping;                                 /*!< Ping finished. Use with \ref LWESP_EVT_PING event */
 #endif /* LWESP_CFG_PING || __DOXYGEN__ */
-#if LWESP_CFG_PING || __DOXYGEN__
+#if LWESP_CFG_SNTP || __DOXYGEN__
         struct {
             lwespr_t res;                       /*!< Result of command */
             const lwesp_datetime_t* dt;         /*!< Pointer to datetime structure */


### PR DESCRIPTION
I noted that this is already fixed upstream (there was also some refactoring in there -- filename change at least). 

This is required to enable NTP API from the ESP32. 