### PR TITLE
Add support to join wifi mesh

### DIFF
--- a/lwesp/src/include/lwesp/lwesp_private.h
+++ b/lwesp/src/include/lwesp/lwesp_private.h
@@ -292,9 +292,10 @@ typedef struct lwesp_msg {
         } wifi_mode;                /*!< When message type \ref LWESP_CMD_WIFI_CWMODE is used */
 #if LWESP_CFG_MODE_STATION || __DOXYGEN__
         struct {
-            const char* name;       /*!< AP name */
-            const char* pass;       /*!< AP password */
+            const char* name;       /*!< AP name or MESH AP name if mesh_id != 0 */
+            const char* pass;       /*!< AP password or MESH AP password if mesh_id != 0 */
             const lwesp_mac_t* mac; /*!< Specific MAC address to use when connecting to AP */
+            const char* mesh_id;    /*!< Mesh ID. format: 00:00:00:00:00:00 */
             uint8_t error_num;      /*!< Error number on connecting */
         } sta_join;                 /*!< Message for joining to access point */
 

--- a/lwesp/src/include/lwesp/lwesp_sta.h
+++ b/lwesp/src/include/lwesp/lwesp_sta.h
@@ -49,6 +49,8 @@ extern "C" {
 
 lwespr_t lwesp_sta_join(const char* name, const char* pass, const lwesp_mac_t* mac, const lwesp_api_cmd_evt_fn evt_fn,
                         void* const evt_arg, const uint32_t blocking);
+lwespr_t lwesp_sta_join_mesh(const char* name, const char* pass, const char* mesh_id, const lwesp_api_cmd_evt_fn evt_fn,
+               void* const evt_arg, const uint32_t blocking);
 lwespr_t lwesp_sta_quit(const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking);
 lwespr_t lwesp_sta_autojoin(uint8_t en, const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg,
                             const uint32_t blocking);

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -1977,10 +1977,18 @@ lwespi_initiate_cmd(lwesp_msg_t* msg) {
 #if LWESP_CFG_MODE_STATION
         case LWESP_CMD_WIFI_CWJAP: { /* Try to join to access point */
             AT_PORT_SEND_BEGIN_AT();
-            AT_PORT_SEND_CONST_STR("+CWJAP=");
+            if (msg->msg.sta_join.mesh_id){
+                AT_PORT_SEND_CONST_STR("+CWJAPMESH=");
+            }
+            else{
+                AT_PORT_SEND_CONST_STR("+CWJAP=");
+            }
             lwespi_send_string(msg->msg.sta_join.name, 1, 1, 0);
             lwespi_send_string(msg->msg.sta_join.pass, 1, 1, 1);
-            if (msg->msg.sta_join.mac != NULL) {
+            if (msg->msg.sta_join.mesh_id) {
+                lwespi_send_string(msg->msg.sta_join.mesh_id, 1, 1, 1);
+            }
+            if (msg->msg.sta_join.mac) {
                 lwespi_send_mac(msg->msg.sta_join.mac, 1, 1);
             }
             AT_PORT_SEND_END_AT();

--- a/lwesp/src/lwesp/lwesp_sta.c
+++ b/lwesp/src/lwesp/lwesp_sta.c
@@ -82,6 +82,38 @@ lwesp_sta_join(const char* name, const char* pass, const lwesp_mac_t* mac, const
     LWESP_MSG_VAR_REF(msg).msg.sta_join.name = name;
     LWESP_MSG_VAR_REF(msg).msg.sta_join.pass = pass;
     LWESP_MSG_VAR_REF(msg).msg.sta_join.mac = mac;
+    LWESP_MSG_VAR_REF(msg).msg.sta_join.mesh_id = NULL;
+
+    return lwespi_send_msg_to_producer_mbox(&LWESP_MSG_VAR_REF(msg), lwespi_initiate_cmd, 30000);
+}
+
+/**
+ * \brief           Join AP as wifi mesh
+ *
+ * Configuration changes will be saved in the NVS area of ESP device.
+ *
+ * \param[in]       name: SSID of access point to connect to
+ * \param[in]       pass: Password of access point. Use `NULL` if AP does not have password
+ * \param[in]       mesh_id: Mesh Id,  format: 00:00:00:00:00:00
+ * \param[in]       evt_fn: Callback function called when command has finished. Set to `NULL` when not used
+ * \param[in]       evt_arg: Custom argument for event callback function
+ * \param[in]       blocking: Status whether command should be blocking or not
+ * \return          \ref lwespOK on success, member of \ref lwespr_t enumeration otherwise
+ */
+lwespr_t
+lwesp_sta_join_mesh(const char* name, const char* pass, const char* mesh_id, const lwesp_api_cmd_evt_fn evt_fn,
+               void* const evt_arg, const uint32_t blocking) {
+    LWESP_MSG_VAR_DEFINE(msg);
+
+    LWESP_ASSERT(name != NULL);
+
+    LWESP_MSG_VAR_ALLOC(msg, blocking);
+    LWESP_MSG_VAR_SET_EVT(msg, evt_fn, evt_arg);
+    LWESP_MSG_VAR_REF(msg).cmd_def = LWESP_CMD_WIFI_CWJAP;
+    LWESP_MSG_VAR_REF(msg).msg.sta_join.name = name;
+    LWESP_MSG_VAR_REF(msg).msg.sta_join.pass = pass;
+    LWESP_MSG_VAR_REF(msg).msg.sta_join.mac = NULL;
+    LWESP_MSG_VAR_REF(msg).msg.sta_join.mesh_id = mesh_id;
 
     return lwespi_send_msg_to_producer_mbox(&LWESP_MSG_VAR_REF(msg), lwespi_initiate_cmd, 30000);
 }


### PR DESCRIPTION
Wifi mesh uses a custom AT command (CWJAPMESH), similar to CWJAP. Wifi mesh doesn't support AP MAC address.
